### PR TITLE
health sync and offraid saving

### DIFF
--- a/src/classes/offraid.js
+++ b/src/classes/offraid.js
@@ -289,7 +289,8 @@ function saveProgress(offraidData, sessionID) {
         return;
     } else {
         pmcData = setInventory(pmcData, offraidData.profile);
-        health_f.healthServer.applyHealth(pmcData, sessionID);
+        health_f.healthServer.saveHealth(pmcData, offraidData.health, sessionID);
+        // health_f.healthServer.applyHealth(pmcData, sessionID);
     }
 
     // remove inventory if player died and send insurance items

--- a/src/responses/health.js
+++ b/src/responses/health.js
@@ -1,18 +1,25 @@
 "use strict";
 
+function syncHealth(url, info, sessionID) {
+    let pmcData = profile_f.profileServer.getPmcProfile(sessionID);
+    health_f.healthServer.saveHealth(pmcData, info, sessionID);
+    return response_f.nullResponse();
+}
+
 function updateHealth(url, info, sessionID) {
     health_f.healthServer.updateHealth(info, sessionID);
     return response_f.nullResponse();
 }
 
 function offraidEat(pmcData, body, sessionID) {
-    return response_f.getBody(health_f.healthServer.offraidEat(pmcData, body, sessionID));
+    return health_f.healthServer.offraidEat(pmcData, body, sessionID);
 }
 
 function offraidHeal(pmcData, body, sessionID) {
-    return response_f.getBody(ealth_f.healthServer.offraidHeal(pmcData, body, sessionID));
+    return health_f.healthServer.offraidHeal(pmcData, body, sessionID);
 }
 
+router.addStaticRoute("/player/health/sync", syncHealth);
 router.addStaticRoute("/player/health/events", updateHealth);
 item_f.itemServer.addRoute("Eat", offraidEat);
 item_f.itemServer.addRoute("Heal", offraidHeal);


### PR DESCRIPTION
The implementation of maintaining the health of the main character.
I hope the JS gurus fix the code)

Requires a client with patches to save hp.

The main idea: save hp after the raid and do synchronization by timer in the menu.

Processing requests for treatment and nutrition is simplified to change items in the inventory. The main work is when synchronizing hp.

The request 'player / health / events' is not used, I just did not touch it.